### PR TITLE
fix: skip abstract commands and add event-listener relationship overview

### DIFF
--- a/src/Mappers/CommandMapper.php
+++ b/src/Mappers/CommandMapper.php
@@ -38,6 +38,13 @@ class CommandMapper implements ComponentMapper
                     class_exists($fqcn) &&
                     is_subclass_of($fqcn, Command::class)
                 ) {
+                    $reflection = new ReflectionClass($fqcn);
+
+                    // Skip abstract classes - they cannot be instantiated
+                    if ($reflection->isAbstract()) {
+                        continue;
+                    }
+
                     $instance = app($fqcn);
                     $commands[] = $this->analyzeCommand($instance);
                 }


### PR DESCRIPTION
## Summary

- **Issue #36**: Skip abstract command classes during scanning to prevent instantiation errors
- **Issue #37**: Add event-listener relationship overview by scanning EventServiceProvider and analyzing handle() method type-hints

## Changes

### CommandMapper.php
- Added `ReflectionClass::isAbstract()` check before instantiating command classes

### EventMapper.php
- Added `buildEventListenerMap()` to scan EventServiceProvider files
- Implemented `findListeners()` with dual approach:
  - Parse EventServiceProvider's `$listen` property
  - Analyze Listener classes' handle() method type-hints
- Added `getEventListenerMap()` public method for external access
- Enhanced listeners data structure with source info

## Test plan

- [x] All existing tests pass (90 tests, 536 assertions)
- [x] PHPStan analysis passes (level 5)
- [x] Pint code style passes
- [ ] Manual testing with abstract commands
- [ ] Manual testing with event-listener mappings

Closes #36
Closes #37