### PR TITLE
fix: detect event listeners with union types and custom paths

### DIFF
--- a/src/Config/atlas.php
+++ b/src/Config/atlas.php
@@ -83,6 +83,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Component Paths Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure custom paths for component scanning. By default, Atlas scans
+    | the standard Laravel directories. Add custom paths here if your
+    | components are in non-standard locations (e.g., domain-driven design).
+    |
+    | Example:
+    | 'listeners' => [
+    |     app_path('Listeners'),
+    |     app_path('Domain/Orders/Listeners'),
+    |     app_path('Domain/Users/Listeners'),
+    | ],
+    |
+    */
+
+    'paths' => [
+        'listeners' => [
+            // Default: app_path('Listeners')
+            // Add custom listener paths here
+        ],
+        'events' => [
+            // Default: app_path('Events')
+            // Add custom event paths here
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Component Detection Configuration
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
- Add support for **union types** in `handle()` method (e.g., `EventA|EventB $event`)
- Add **configurable listener/event paths** via `atlas.paths` config for custom namespaces (DDD, modular structure)
- Add `typeMatchesEvent()` method for flexible type matching including union and nullable types

## Changes
| File | Description |
|------|-------------|
| `src/Mappers/EventMapper.php` | Added `typeMatchesEvent()`, `getListenerPaths()`, `getEventPaths()` |
| `src/Mappers/ListenerMapper.php` | Added `getDefaultPaths()` for configurable paths |
| `src/Config/atlas.php` | Added `paths.listeners` and `paths.events` configuration |

## Configuration Example
```php
// config/atlas.php
'paths' => [
    'listeners' => [
        app_path('Listeners'),
        app_path('Domain/Orders/Listeners'),
        app_path('Domain/Users/Listeners'),
    ],
    'events' => [
        app_path('Events'),
        app_path('Domain/Orders/Events'),
    ],
],
```

## Test plan
- [x] All existing tests pass (102 passed)
- [x] PHPStan analysis clean (2 pre-existing errors unrelated to this PR)

Closes #42