### PR TITLE
fix: UI improvements - hide empty sections and fix card heights

### DIFF
--- a/resources/views/exports/layout.blade.php
+++ b/resources/views/exports/layout.blade.php
@@ -168,20 +168,9 @@
             to { opacity: 1; transform: translateY(0); }
         }
         
-        /* Card layout with footer at bottom */
-        .grid.auto-rows-fr > div {
-            display: flex;
-            flex-direction: column;
-        }
-        
-        /* Push footer to bottom by making the content before it expand */
-        .grid.auto-rows-fr > div > *:last-child {
-            margin-top: auto;
-        }
-        
-        /* Ensure the footer section has the proper spacing */
-        .grid.auto-rows-fr > div > *:last-child[class*="border-t"] {
-            margin-top: auto;
+        /* Card layout - natural height */
+        .card-grid > div {
+            height: fit-content;
         }
     </style>
 </head>
@@ -416,7 +405,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($models as $model)
                                 @include('atlas::exports.partials.model-card', ['item' => $model])
                             @endforeach
@@ -437,7 +426,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($controllers as $controller)
                                 @include('atlas::exports.partials.controller-card', ['item' => $controller])
                             @endforeach
@@ -545,7 +534,7 @@
                         </div>
 
                         {{-- Routes Grid --}}
-                        <div id="routes-grid" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div id="routes-grid" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($routes as $route)
                                 <div class="route-card"
                                      data-route-uri="{{ strtolower($route['uri']) }}"
@@ -580,7 +569,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($commands as $command)
                                 @include('atlas::exports.partials.command-card', ['item' => $command])
                             @endforeach
@@ -601,7 +590,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($services as $service)
                                 @include('atlas::exports.partials.service-card', ['item' => $service])
                             @endforeach
@@ -622,7 +611,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($jobs as $job)
                                 @include('atlas::exports.partials.job-card', ['item' => $job])
                             @endforeach
@@ -643,7 +632,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($events as $event)
                                 @include('atlas::exports.partials.event-card', ['item' => $event])
                             @endforeach
@@ -664,7 +653,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($listeners as $listener)
                                 @include('atlas::exports.partials.listener-card', ['item' => $listener])
                             @endforeach
@@ -685,7 +674,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($notifications as $notification)
                                 @include('atlas::exports.partials.notification-card', ['item' => $notification])
                             @endforeach
@@ -706,7 +695,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($middlewares as $middleware)
                                 @include('atlas::exports.partials.middleware-card', ['item' => $middleware])
                             @endforeach
@@ -727,7 +716,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($form_requests as $form_request)
                                 @include('atlas::exports.partials.form-request-card', ['item' => $form_request])
                             @endforeach
@@ -748,7 +737,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($resources as $resource)
                                 @include('atlas::exports.partials.resource-card', ['item' => $resource])
                             @endforeach
@@ -769,7 +758,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($policies as $policy)
                                 @include('atlas::exports.partials.policy-card', ['item' => $policy])
                             @endforeach
@@ -790,7 +779,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($rules as $rule)
                                 @include('atlas::exports.partials.rule-card', ['item' => $rule])
                             @endforeach
@@ -811,7 +800,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($observers as $observer)
                                 @include('atlas::exports.partials.observer-card', ['item' => $observer])
                             @endforeach
@@ -832,7 +821,7 @@
                             </div>
                         </div>
                         
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 items-start">
                             @foreach ($actions as $action)
                                 @include('atlas::exports.partials.action-card', ['item' => $action])
                             @endforeach

--- a/resources/views/exports/partials/common/flow-section.blade.php
+++ b/resources/views/exports/partials/common/flow-section.blade.php
@@ -3,7 +3,45 @@
     @param array $flow - Flow data
     @param string $type - Component type for conditional rendering
 --}}
-@if (!empty($flow['jobs']) || !empty($flow['events']) || !empty($flow['notifications']) || !empty($flow['mails']) || !empty($flow['logs']) || !empty($flow['dependencies']) || !empty($flow['calls']) || !empty($flow['observers']) || !empty($flow['facades']) || !empty($flow['cache']) || !empty($flow['auth']) || !empty($flow['exceptions']) || !empty($flow['services']) || !empty($flow['uses']) || !empty($flow['models']) || !empty($flow['rules']) || !empty($flow['policies']) || !empty($flow['validations']))
+@php
+    // Helper function to check if dependencies has any actual content
+    $hasRealDependencies = function($deps) {
+        if (!is_array($deps) || empty($deps)) {
+            return false;
+        }
+        // Check if it's a simple array of strings
+        if (isset($deps[0]) && is_string($deps[0])) {
+            return true;
+        }
+        // Check if any nested array has content
+        foreach ($deps as $group) {
+            if (is_array($group) && !empty($group)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    
+    $showFlowSection = !empty($flow['jobs']) 
+        || !empty($flow['events']) 
+        || !empty($flow['notifications']) 
+        || !empty($flow['mails']) 
+        || !empty($flow['logs']) 
+        || !empty($flow['calls']) 
+        || !empty($flow['observers']) 
+        || !empty($flow['facades']) 
+        || !empty($flow['cache']) 
+        || !empty($flow['auth']) 
+        || !empty($flow['exceptions']) 
+        || !empty($flow['services']) 
+        || !empty($flow['uses']) 
+        || !empty($flow['models']) 
+        || !empty($flow['rules']) 
+        || !empty($flow['policies']) 
+        || !empty($flow['validations'])
+        || (isset($flow['dependencies']) && $hasRealDependencies($flow['dependencies']));
+@endphp
+@if ($showFlowSection)
     <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
         <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
             <span class="mr-2">🔄</span>
@@ -302,7 +340,7 @@
         </div>
 
         {{-- Dependencies (Full width) --}}
-        @if (!empty($flow['dependencies']))
+        @if (isset($flow['dependencies']) && $hasRealDependencies($flow['dependencies']))
             <div class="mt-4">
                 <div class="flex items-center mb-2">
                     <span class="text-sm mr-2">🧩</span>

--- a/resources/views/exports/partials/form-request-card.blade.php
+++ b/resources/views/exports/partials/form-request-card.blade.php
@@ -59,9 +59,9 @@
                         Validation Rules ({{ count($form_request['rules']) }})
                     </h4>
                 </div>
-                <div class="overflow-x-auto">
-                    <table class="w-full text-xs border rounded-lg overflow-hidden">
-                        <thead class="bg-gray-100 dark:bg-gray-700">
+                <div class="overflow-auto max-h-80 border rounded-lg">
+                    <table class="w-full text-xs">
+                        <thead class="bg-gray-100 dark:bg-gray-700 sticky top-0">
                             <tr>
                                 <th class="p-3 text-left font-medium">Field</th>
                                 <th class="p-3 text-left font-medium">Rules</th>
@@ -125,9 +125,9 @@
                         Custom Messages ({{ count($form_request['messages']) }})
                     </h4>
                 </div>
-                <div class="overflow-x-auto">
-                    <table class="w-full text-xs border rounded-lg overflow-hidden">
-                        <thead class="bg-gray-100 dark:bg-gray-700">
+                <div class="overflow-auto max-h-60 border rounded-lg">
+                    <table class="w-full text-xs">
+                        <thead class="bg-gray-100 dark:bg-gray-700 sticky top-0">
                             <tr>
                                 <th class="p-3 text-left font-medium">Rule</th>
                                 <th class="p-3 text-left font-medium">Custom Message</th>


### PR DESCRIPTION
## Summary
- **Hide Flow & Dependencies** section when all sub-arrays are empty (not just the parent array)
- **Form Request cards** - Add scrollable tables with sticky headers
- **Card heights** - Replace `auto-rows-fr` with `items-start` for natural card heights

## Changes
| File | Description |
|------|-------------|
| `flow-section.blade.php` | Added `$hasRealDependencies()` helper to check nested arrays |
| `form-request-card.blade.php` | Added `max-h-80 overflow-auto` + `sticky top-0` headers |
| `layout.blade.php` | Replaced `auto-rows-fr` with `items-start` in all grids |

## Before/After
- **Before**: Empty "Flow & Dependencies" shown, Form Request cards very tall, uneven card heights
- **After**: Empty sections hidden, scrollable tables, natural card heights

## Test plan
- [x] Visual inspection of exported HTML
- [x] Form Request cards with many rules now scroll instead of expanding

Closes #43