### PR TITLE
Improve regex for finding listener event dispatch flows

### DIFF
--- a/src/Mappers/ListenerMapper.php
+++ b/src/Mappers/ListenerMapper.php
@@ -183,7 +183,7 @@ class ListenerMapper implements ComponentMapper
         }
 
         // Events dispatched via Event::dispatch()
-        if (preg_match_all('/Event::dispatch\(\s*new\s+([A-Z][\w\\\\]+)/', $source, $matches)) {
+        if (preg_match_all('/(?:([A-Z][\w\\\\]+)::dispatch|new\s+([A-Z][\w\\\\]+))/', $source, $matches)) {
             foreach ($matches[1] as $class) {
                 $flow['events'][] = ['class' => $class];
             }


### PR DESCRIPTION
## Description

This adds custom event::dispatch aswell to the flows.

## Related Issue

Closes #57 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Changed regex to also find regular ::dispatch

## Testing

- [ ] Tests added/updated for the changes
- [x] All existing tests pass
- [ ] New tests pass
- [x] Manual testing performed

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code is properly documented
- [x] No unnecessary debug code or comments left

## Additional Notes

@Grazulex In the future to make sure we really can make a good flow diagram with mermaid multiple things have to happen:
Right now the flows do not work recursively, which makes diagrams impossible.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes